### PR TITLE
views for devices working, plus using max concurrent jobs for devices

### DIFF
--- a/nanobsd/plugins/bacula_pbi/resources/baculaUI/freenas/views.py
+++ b/nanobsd/plugins/bacula_pbi/resources/baculaUI/freenas/views.py
@@ -299,7 +299,7 @@ def edit(request, plugin_id):
 
     form = forms.BaculaSDStorageForm(request.POST,
         instance=bacula,
-        jail=jail)
+        jail_path=jail_path)
     if form.is_valid():
         form.save()
         return JsonResponse(request,

--- a/nanobsd/plugins/bacula_pbi/resources/ix-bacula-sd
+++ b/nanobsd/plugins/bacula_pbi/resources/ix-bacula-sd
@@ -106,7 +106,8 @@ print_sql_device () {
 	       baculasd_dev_randomaccess,
 	       0,
 	       baculasd_dev_removablemedia,
-	       baculasd_dev_alwaysopen
+	       baculasd_dev_alwaysopen,
+	       baculasd_dev_maximumconcurrentjobs
 	FROM freenas_baculasddevice             AS r,
 	     freenas_baculasddeviceassignment   AS a
 	WHERE r.id = a.baculasd_map_device_id AND
@@ -127,7 +128,8 @@ print_device_stanzas () {
                RANDOM_ACCESS  \
                AUTOMATIC_MOUNT \
                REMOVABLE_MEDIA \
-               ALWAYS_OPEN
+               ALWAYS_OPEN \
+               MAX_DEV_JOBS
     do
       echo 'Device {'
       [ ${NAME}           ] && echo "  Name = ${NAME}"
@@ -138,6 +140,7 @@ print_device_stanzas () {
       [ ${AUTOMATIC_MOUNT} ] && echo "  Automatic Mount = $(trans_bool ${AUTOMATIC_MOUNT})"
       [ ${REMOVABLE_MEDIA} ] && echo "  Removable Media = $(trans_bool ${REMOVABLE_MEDIA})"
       [ ${ALWAYS_OPEN}     ] && echo "  Always Open = $(trans_bool ${ALWAYS_OPEN})"
+      [ ${MAX_DEV_JOBS}    ] && echo "  Maximum Concurrent Jobs = ${MAX_DEV_JOBS}"
       echo '}'
     done
 }


### PR DESCRIPTION
still open is the copy of
bacula-sd to /etc/rc.d/bacula-sd.
I need to learn a bit about intallation of a plugin first.
