### PR TITLE
creating script with correct port as instance-identifier

### DIFF
--- a/nanobsd/plugins/bacula_pbi/resources/bacula
+++ b/nanobsd/plugins/bacula_pbi/resources/bacula
@@ -53,7 +53,12 @@ bacula_start()
 			baculasd_st_sdport
 	 	FROM freenas_baculasdstorage" | \
 	while read -r port; do
-		${BACULA_SD} -c ${BACULA_PATH}/etc/bacula-sd.${port}.conf
+                # --- as created by ix-bacula-sd
+                if [ -r /tmp/bacula-sd-${port} ]; then
+                   /tmp/bacula-sd-${port} > /tmp/bacula-${port}.log 2>&1
+                else
+                   ${BACULA_SD} -v -c ${BACULA_PATH}/etc/bacula-sd.${port}.conf
+                fi
 	done
 
 }

--- a/nanobsd/plugins/bacula_pbi/resources/ix-bacula-sd
+++ b/nanobsd/plugins/bacula_pbi/resources/ix-bacula-sd
@@ -33,7 +33,7 @@ print_sql_storage () {
   cat <<- EOT
 	SELECT baculasd_st_name,
 	       baculasd_st_sdport,
-	       '/usr/pbi/bacula',
+	       $BACULA_HOME,
 	       '/var/run',
 	       baculasd_st_maximumconcurrentjobs
 	FROM freenas_baculasdstorage

--- a/nanobsd/plugins/bacula_pbi/resources/ix-bacula-sd
+++ b/nanobsd/plugins/bacula_pbi/resources/ix-bacula-sd
@@ -33,7 +33,7 @@ print_sql_storage () {
   cat <<- EOT
 	SELECT baculasd_st_name,
 	       baculasd_st_sdport,
-	       $BACULA_HOME,
+	       '/var/db/bacula',
 	       '/var/run',
 	       baculasd_st_maximumconcurrentjobs
 	FROM freenas_baculasdstorage
@@ -56,6 +56,7 @@ print_storage_stanza () {
       echo 'Storage {'
       [ ${NAME}                    ] && echo "  Name = ${NAME}"
       [ ${SDPORT}                  ] && echo "  SDPort = ${SDPORT}"
+# --- somewhere writable to bacula user
       [ ${WORKING_DIRECTORY}       ] && echo "  Working Directory = ${WORKING_DIRECTORY}"
       [ ${PID_DIRECTORY}           ] && echo "  Pid Directory = ${PID_DIRECTORY}"
       [ ${MAXIMUM_CONCURRENT_JOBS} ] && echo "  Maximum Concurrent Jobs = ${MAXIMUM_CONCURRENT_JOBS}"

--- a/nanobsd/plugins/bacula_pbi/resources/ix-bacula-sd
+++ b/nanobsd/plugins/bacula_pbi/resources/ix-bacula-sd
@@ -33,7 +33,7 @@ print_sql_storage () {
   cat <<- EOT
 	SELECT baculasd_st_name,
 	       baculasd_st_sdport,
-	       '/usr/pbi',
+	       '/usr/pbi/bacula',
 	       '/var/run',
 	       baculasd_st_maximumconcurrentjobs
 	FROM freenas_baculasdstorage
@@ -211,21 +211,6 @@ check_conf () {
   grep -q ^Messages ${BACULA_SD_CFG} || return 1
 }
 
-update_rc_file () {
-  local RC_FILE="/etc/rc.d/bacula-sd"
-  local TMP_FILE="/tmp/bacula-sd.rc.tmp"
-
-  grep -q '^command=/tmp/bacula-sd' ${RC_FILE} && return
-
-  sed -e 's/^command=/procname=/'  \
-      -e 's/^pidfile=/#procname=/' \
-      ${RC_FILE} >                \
-      ${TMP_FILE}
-
-  sed -e '/^procname/a\
-command=/tmp/bacula-sd' ${TMP_FILE} > ${RC_FILE}
-}
-
 print_sql_storage_id () {
   cat <<- EOT
 	SELECT id,
@@ -242,20 +227,17 @@ generate_bacula_sd()
   local BACULA_SD_NEW_CMD="/tmp/bacula-sd"
   local BACULA_SD_COMMAND="/usr/local/sbin/bacula-sd"
   local BACULA_SD_FLAGS="-u bacula -g bacula -v"
-  local BACULA_SD_PID=""
+  local BACULA_SD_PORT=""
   local STORAGE_ID=""
   local PROCEED_IOERR=""
   local P_FLAG=""
 
-  > ${BACULA_SD_NEW_CMD}
-  chmod 700 ${BACULA_SD_NEW_CMD}
-
   query_db "${STATEMENT}"    \
   | while read STORAGE_ID    \
-               BACULA_SD_PID \
+               BACULA_SD_PORT \
                PROCEED_IOERR
     do
-      BACULA_SD_CFG=${BACULA_HOME}/etc/bacula-sd.${BACULA_SD_PID}.conf
+      BACULA_SD_CFG=${BACULA_HOME}/etc/bacula-sd.${BACULA_SD_PORT}.conf
 
       if [ $PROCEED_IOERR -eq 1 ]
       then P_FLAG=" -p"
@@ -266,12 +248,14 @@ generate_bacula_sd()
 
       if check_conf ${BACULA_SD_CFG}
       then
+      # --- if conf is ok generate start-stop-script for this sd-instance/port
+        > ${BACULA_SD_NEW_CMD}-${BACULA_SD_PORT}
+        chmod 700 ${BACULA_SD_NEW_CMD}-${BACULA_SD_PORT}
         echo "${BACULA_SD_COMMAND} ${BACULA_SD_FLAGS}${P_FLAG} -c ${BACULA_SD_CFG}" \
-          >> ${BACULA_SD_NEW_CMD}
+          >> ${BACULA_SD_NEW_CMD}-${BACULA_SD_PORT}
       fi
 
-      update_rc_file
-    done
+   done
 }
 
 name=ix-bacula-sd


### PR DESCRIPTION
Hi,
in ix-bacula-sd I modified the variables and the final name of the script.
so it is no more wrongly "$PID", this is actually "$PORT" see lines 245~258. This $PORT is alo used
to create more than one start-stop-script in case of more than one SD, all based on the $PORT

And in bacula I first look at this PORT-based start-stop-script, if found use it. The else is only
for old leftover scripts and can be deleted.

By the way, bacula is now run with proper user, statefile can be written in directory /var/db/bacula, which is owned by bacula. ... or create a new directory for this, if you dont like this.

But still after some tuning in this scripts no chance because I can not find bacula-sd 7.0.5 for freebsd and
I have dont have any development system with freebsd. So sadly I have to say baybay to frenas, as this is absolutly NOGO for me.

Are there any other steps necessary (for You) to integrate this changed scripts as freenas-Plugin, because after compete delete and reinstall of the bacula-sd-plugin I still got the old scripts?  

cu Harvey
